### PR TITLE
Change upper bounds of template-haskell to include 2.16

### DIFF
--- a/haskellish.cabal
+++ b/haskellish.cabal
@@ -30,7 +30,7 @@ library
       base >=4.8 && <5
     , haskell-src-exts >=1.17.1 && <1.24
     , mtl >= 2.2.2 && <2.3
-    , template-haskell >= 2.10.0.0 && < 2.16
+    , template-haskell >= 2.10.0.0 && < 2.17
     , containers < 0.7
     , text < 1.3
 


### PR DESCRIPTION
I haven't tested this, but the current upper bounds seems to be stopping 0.2.4.x of haskellish from building: https://hackage.haskell.org/package/haskellish-0.2.4.2/reports/
I think this might be what is causing the stack tests on tidal problems.