### PR TITLE
bump outdated upper bounds

### DIFF
--- a/haskellish.cabal
+++ b/haskellish.cabal
@@ -30,9 +30,9 @@ library
       base >=4.8 && <5
     , haskell-src-exts >=1.17.1 && <1.24
     , mtl >= 2.2.2 && <2.3
-    , template-haskell >= 2.10.0.0 && < 2.17
+    , template-haskell >= 2.10.0.0 && < 2.20
     , containers < 0.7
-    , text < 1.3
+    , text < 2.1
 
 source-repository head
   type:     git


### PR DESCRIPTION
Hi @dktr0 could you do a new cabal release with this please, so tidal-parse builds on the latest ghc, thanks!
