### PR TITLE
Bump upper bounds

### DIFF
--- a/haskellish.cabal
+++ b/haskellish.cabal
@@ -30,9 +30,9 @@ library
       base >=4.8 && <5
     , haskell-src-exts >=1.17.1 && <1.24
     , mtl >= 2.2.2 && <2.4
-    , template-haskell >= 2.10.0.0 && < 2.21
-    , containers < 0.7
-    , text < 2.1
+    , template-haskell >= 2.10.0.0 && < 2.22
+    , containers < 0.8
+    , text < 2.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
Currently haskellish isn't building on recent GHCs:

https://github.com/tidalcycles/Tidal/actions/runs/8734592471/job/23965589357?pr=1072

.. so here's a PR to bump upper bounds to latest versions.

I haven't tested whether it actually works on the new versions, but think it probably is! Once the bounds are updated we can re-run the tidal tests to check.

If you don't fancy doing a new release right now @dktr0, you can increase the upper bounds on the current release in hackage:
https://hackage.haskell.org/package/haskellish/maintain

Thanks !